### PR TITLE
Add demoOnly prop to hide the Live source-mode toggle

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neural-amp-modeler-wasm",
-  "version": "1.0.74",
+  "version": "1.0.75",
   "description": "Neural Amp Modeler WebAssembly React Component",
   "type": "module",
   "main": "dist/index.js",

--- a/ui/src/components/Player/AcordianPlayer.tsx
+++ b/ui/src/components/Player/AcordianPlayer.tsx
@@ -26,6 +26,7 @@ const PlayerFC: React.FC<T3kAcordianPlayerProps> = ({
   }),
   previewMode,
   forceA2Nano,
+  demoOnly,
   onPlayDemo,
   onPlayLive,
   onModelChange,
@@ -88,7 +89,7 @@ const PlayerFC: React.FC<T3kAcordianPlayerProps> = ({
         <div className='flex items-center gap-4 overflow-hidden min-h-[80px]'>
           {disabled ? (
             <DisabledPlaybar infoSlot={infoSlot} />
-          ) : core.sourceMode === 'demo' ? (
+          ) : demoOnly || core.sourceMode === 'demo' ? (
             <DemoPlaybar
               togglePlay={core.togglePlay}
               isThisPlayerActive={core.isThisPlayerActive}
@@ -127,25 +128,27 @@ const PlayerFC: React.FC<T3kAcordianPlayerProps> = ({
         {expanded && !disabled && (
           <>
             <div className='flex flex-col gap-6'>
-              {/* Toggle between demo and live */}
-              <Tabs
-                tabs={SOURCE_MODE_OPTIONS.map(o => (
-                  <div className='flex gap-2 items-center'>
-                    {o.value === 'demo' ? (
-                      <Demo size={20} />
-                    ) : (
-                      <PlayIcon size={20} />
-                    )}
-                    <span>{o.label === 'Live' ? 'Play' : o.label}</span>
-                  </div>
-                ))}
-                activeTab={SOURCE_MODE_OPTIONS.findIndex(
-                  o => o.value === core.sourceMode
-                )}
-                setActiveTab={index =>
-                  core.handleSourceModeChange(SOURCE_MODE_OPTIONS[index].value)
-                }
-              />
+              {/* Toggle between demo and live (hidden when demoOnly) */}
+              {!demoOnly && (
+                <Tabs
+                  tabs={SOURCE_MODE_OPTIONS.map(o => (
+                    <div className='flex gap-2 items-center'>
+                      {o.value === 'demo' ? (
+                        <Demo size={20} />
+                      ) : (
+                        <PlayIcon size={20} />
+                      )}
+                      <span>{o.label === 'Live' ? 'Play' : o.label}</span>
+                    </div>
+                  ))}
+                  activeTab={SOURCE_MODE_OPTIONS.findIndex(
+                    o => o.value === core.sourceMode
+                  )}
+                  setActiveTab={index =>
+                    core.handleSourceModeChange(SOURCE_MODE_OPTIONS[index].value)
+                  }
+                />
+              )}
               <PlayerSettings
                 previewMode={previewMode}
                 disabled={disabled}

--- a/ui/src/components/Player/Player.tsx
+++ b/ui/src/components/Player/Player.tsx
@@ -21,6 +21,7 @@ const PlayerFC: React.FC<T3kPlayerProps> = ({
   inputs = DEFAULT_INPUTS,
   previewMode,
   forceA2Nano,
+  demoOnly,
   onPlayDemo,
   onPlayLive,
   onModelChange,
@@ -47,7 +48,7 @@ const PlayerFC: React.FC<T3kPlayerProps> = ({
     <div className='bg-zinc-900 border border-zinc-700 text-white p-4 lg:p-8 pt-0 lg:pt-2 rounded-xl w-full flex flex-col gap-6'>
       <div className='flex flex-col'>
         <div className='flex items-center min-h-[80px]'>
-          {core.sourceMode === 'demo' ? (
+          {demoOnly || core.sourceMode === 'demo' ? (
             <DemoPlaybar
               togglePlay={core.togglePlay}
               isThisPlayerActive={core.isThisPlayerActive}
@@ -73,25 +74,27 @@ const PlayerFC: React.FC<T3kPlayerProps> = ({
           )}
         </div>
         <div className='flex flex-col gap-6'>
-          {/* Toggle between demo and live */}
-          <Tabs
-            tabs={SOURCE_MODE_OPTIONS.map(o => (
-              <div className='flex gap-2 items-center'>
-                {o.value === 'demo' ? (
-                  <Demo size={20} />
-                ) : (
-                  <PlayIcon size={20} />
-                )}
-                <span>{o.label === 'Live' ? 'Play' : o.label}</span>
-              </div>
-            ))}
-            activeTab={SOURCE_MODE_OPTIONS.findIndex(
-              o => o.value === core.sourceMode
-            )}
-            setActiveTab={index =>
-              core.handleSourceModeChange(SOURCE_MODE_OPTIONS[index].value)
-            }
-          />
+          {/* Toggle between demo and live (hidden when demoOnly) */}
+          {!demoOnly && (
+            <Tabs
+              tabs={SOURCE_MODE_OPTIONS.map(o => (
+                <div className='flex gap-2 items-center'>
+                  {o.value === 'demo' ? (
+                    <Demo size={20} />
+                  ) : (
+                    <PlayIcon size={20} />
+                  )}
+                  <span>{o.label === 'Live' ? 'Play' : o.label}</span>
+                </div>
+              ))}
+              activeTab={SOURCE_MODE_OPTIONS.findIndex(
+                o => o.value === core.sourceMode
+              )}
+              setActiveTab={index =>
+                core.handleSourceModeChange(SOURCE_MODE_OPTIONS[index].value)
+              }
+            />
+          )}
           <PlayerSettings
             previewMode={previewMode}
             bypassed={core.bypassed}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -195,6 +195,11 @@ export interface T3kPlayerProps {
   forceA2Nano?: boolean;
   // When true, the player renders in a disabled state regardless of model contents.
   disabled?: boolean;
+  // When true, hide the Live source-mode toggle and pin the player to Demo
+  // playback. Use where live input isn't available/wanted — e.g. the in-flow
+  // preview player inside the plugin webview, where mic capture and audio
+  // routing aren't supported. Defaults to false (Demo + Live both shown).
+  demoOnly?: boolean;
   onPlayDemo?: ({
     model,
     ir,


### PR DESCRIPTION
demoOnly (on T3kPlayerProps) hides the demo/live Tabs and pins the player to Demo playback; sourceMode already defaults to 'demo', so no engine change is needed. Wired into Player and AcordianPlayer.

Bump 1.0.74 -> 1.0.75.